### PR TITLE
Implement seccomp-bpf sandboxing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,13 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: cargo clippy --all-targets --all-features
-      - run: cargo test
+      - run: cargo test --all-features
       - run: cargo fmt --check
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@v3
-      - run: rustup target add aarch64-linux-android i686-linux-android x86_64-linux-android
+      - run: rustup target add aarch64-linux-android x86_64-linux-android
       - run: ./gradlew build
       - run: ./gradlew dokkaHtml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,8 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "jni",
+ "libc",
+ "seccompiler",
  "sufsort",
  "zstd",
 ]
@@ -585,6 +587,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "seccompiler"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345a3e4dddf721a478089d4697b83c6c0a8f5bf16086f6c13397e4534eb6e2e5"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -46,10 +46,10 @@ android {
     testOptions {
         managedDevices {
             localDevices {
-                create("nexusOneApi30") {
+                create("nexusOneApi34") {
                     device = "Nexus One"
-                    apiLevel = 30
-                    systemImageSource = "aosp-atd"
+                    apiLevel = 34
+                    systemImageSource = "aosp"
                 }
             }
         }
@@ -82,7 +82,6 @@ tasks.register("buildJniLibs") {
 
     val aarch64CcPath = "$toolchainDir/aarch64-linux-android$api-clang"
     val x8664CcPath = "$toolchainDir/x86_64-linux-android$api-clang"
-    val i686CcPath = "$toolchainDir/i686-linux-android$api-clang"
 
     doFirst {
         exec {
@@ -97,7 +96,7 @@ tasks.register("buildJniLibs") {
                 "ina",
                 "--no-default-features",
                 "--features",
-                "java-ffi,patch",
+                "java-ffi,patch,sandbox",
                 "--target",
                 "aarch64-linux-android",
                 "--profile",
@@ -116,28 +115,9 @@ tasks.register("buildJniLibs") {
                 "ina",
                 "--no-default-features",
                 "--features",
-                "java-ffi,patch",
+                "java-ffi,patch,sandbox",
                 "--target",
                 "x86_64-linux-android",
-                "--profile",
-                "cdylib-release",
-            )
-        }
-        exec {
-            environment("AR", "$toolchainDir/llvm-ar")
-            environment("CARGO_TARGET_I686_LINUX_ANDROID_LINKER", i686CcPath)
-            environment("CC_i686-linux-android", i686CcPath)
-
-            commandLine(
-                "cargo",
-                "build",
-                "-p",
-                "ina",
-                "--no-default-features",
-                "--features",
-                "java-ffi,patch",
-                "--target",
-                "i686-linux-android",
                 "--profile",
                 "cdylib-release",
             )
@@ -152,10 +132,6 @@ tasks.register("buildJniLibs") {
         copy {
             from("$rootDir/target/x86_64-linux-android/cdylib-release/libina.so")
             into("$projectDir/src/main/jniLibs/x86_64")
-        }
-        copy {
-            from("$rootDir/target/i686-linux-android/cdylib-release/libina.so")
-            into("$projectDir/src/main/jniLibs/x86")
         }
     }
 }

--- a/android/src/main/java/app/accrescent/ina/Patcher.kt
+++ b/android/src/main/java/app/accrescent/ina/Patcher.kt
@@ -24,5 +24,14 @@ internal class Patcher {
         @JvmStatic
         @Throws(IOException::class)
         external fun patch(oldFileFd: Int, patch: InputStream, out: OutputStream): Long
+
+        /**
+         * Enables the platform sandbox for patching operations
+         *
+         * @return 1 when the sandbox is successfully enabled, 0 when no supported sandbox exists
+         * for the current platform, and -1 if a supported sandbox is detected but enabling it fails
+         */
+        @JvmStatic
+        external fun enableSandbox(): Int
     }
 }

--- a/ina/Cargo.toml
+++ b/ina/Cargo.toml
@@ -17,8 +17,12 @@ bytemuck = { version = "1.15.0", optional = true }
 byteorder = "1.5.0"
 integer-encoding = "4.0.0"
 jni = { version = "0.21.1", optional = true }
+seccompiler = { version = "0.4.0", optional = true }
 sufsort = { path = "../sufsort", optional = true }
 zstd = { version = "0.13.0", default-features = false }
+
+[target.'cfg(all(any(target_os = "linux", target_os = "android"), target_endian = "little", any(target_arch = "aarch64", target_arch = "x86_64")))'.dependencies]
+libc = { version = "0.2.153", optional = true }
 
 [dev-dependencies]
 blake3 = "1.5.1"
@@ -28,6 +32,7 @@ default = ["diff", "patch"]
 diff = ["sufsort"]
 java-ffi = ["bytemuck", "jni"]
 patch = []
+sandbox = ["libc", "seccompiler"]
 
 [lints.rust]
 missing_docs = "warn"

--- a/ina/src/jni.rs
+++ b/ina/src/jni.rs
@@ -141,3 +141,15 @@ impl<'a> Write for OutputStream<'a> {
             .map_err(|e: JniError| IoError::other(e))
     }
 }
+
+#[cfg(feature = "sandbox")]
+#[no_mangle]
+extern "system" fn Java_app_accrescent_ina_Patcher_enableSandbox(
+    _env: JNIEnv,
+    _class: JClass,
+) -> jint {
+    match crate::sandbox::enable_for_patching() {
+        Ok(enabled) => jint::from(enabled),
+        Err(_) => -1,
+    }
+}

--- a/ina/src/lib.rs
+++ b/ina/src/lib.rs
@@ -55,6 +55,8 @@ mod header;
 mod jni;
 #[cfg(feature = "patch")]
 mod patch;
+#[cfg(feature = "sandbox")]
+pub mod sandbox;
 
 #[cfg(feature = "diff")]
 pub use diff::diff;

--- a/ina/src/sandbox/common.rs
+++ b/ina/src/sandbox/common.rs
@@ -1,0 +1,45 @@
+// Copyright 2024 Logan Magee
+//
+// SPDX-License-Identifier: LicenseRef-Proprietary
+
+use std::{
+    error::Error,
+    fmt::{self, Display, Formatter},
+};
+
+/// An error indicating that sandboxing the process failed.
+///
+/// This error is returned by [`enable_for_patching()`] when enabling the platform's sandbox fails.
+///
+/// The set of potential errors is expected to grow as sandboxing support for more platforms is
+/// added.
+///
+/// [`enable_for_patching()`]: super::enable_for_patching
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum SandboxError {
+    /// A seccomp error occurred
+    Seccomp(seccompiler::Error),
+}
+
+impl Display for SandboxError {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            SandboxError::Seccomp(e) => write!(f, "seccomp error: {e}"),
+        }
+    }
+}
+
+impl Error for SandboxError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            SandboxError::Seccomp(e) => e.source(),
+        }
+    }
+}
+
+impl From<seccompiler::Error> for SandboxError {
+    fn from(value: seccompiler::Error) -> Self {
+        SandboxError::Seccomp(value)
+    }
+}

--- a/ina/src/sandbox/mod.rs
+++ b/ina/src/sandbox/mod.rs
@@ -1,0 +1,43 @@
+// Copyright 2024 Logan Magee
+//
+// SPDX-License-Identifier: LicenseRef-Proprietary
+
+//! Sandboxing utilities for Ina operations.
+//!
+//! This module contains functions to enable platform-specific sandboxing that is guaranteed to be
+//! compatible with Ina's operations. They are abstract over the platform targeted, enabling
+//! appropriate sandboxing on platforms with supported sandboxing methods on a best-effort basis,
+//! so it's recommended to call the respective sandboxing functions on all targets whenever
+//! possible to automatically take advantage of additional platform sandbox support.
+//!
+//! The methods are separated by the operation being performed since patching and diffing may use
+//! different platform capabilities.
+//!
+//! # Examples
+//!
+//! ```no_run
+//! use std::fs::File;
+//! use ina::sandbox;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Perform setup for patching before enabling the sandbox
+//! let old = File::open("app-v1.exe")?;
+//! let patch = File::open("app-v1-to-v2.ina")?;
+//! let mut new = File::create("app-v2.exe")?;
+//!
+//! // Enable the platform's sandbox for patching
+//! sandbox::enable_for_patching()?;
+//!
+//! // Patch the blob
+//! ina::patch(old, patch, &mut new)?;
+//! # Ok(())
+//! # }
+//! ```
+
+pub use seccompiler;
+
+mod common;
+mod patch;
+
+pub use common::SandboxError;
+pub use patch::enable as enable_for_patching;

--- a/ina/src/sandbox/patch.rs
+++ b/ina/src/sandbox/patch.rs
@@ -1,0 +1,101 @@
+// Copyright 2024 Logan Magee
+//
+// SPDX-License-Identifier: LicenseRef-Proprietary
+
+use super::common::SandboxError;
+
+/// Enables the platform-specific sandbox for patching
+///
+/// Returns `Ok(true)` if sandboxing was successfully enabled for the current platform and
+/// `Ok(false)` if no supported sandboxing method was detected.
+///
+/// # Errors
+///
+/// Returns an error if a supported sandboxing method is detected on the current platform, but
+/// enabling it fails.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::fs::File;
+/// use ina::sandbox;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// // Perform setup for patching before enabling the sandbox
+/// let old = File::open("app-v1.exe")?;
+/// let patch = File::open("app-v1-to-v2.ina")?;
+/// let mut new = File::create("app-v2.exe")?;
+///
+/// // Enable the platform's sandbox for patching
+/// sandbox::enable_for_patching()?;
+///
+/// // Patch the blob
+/// ina::patch(old, patch, &mut new)?;
+/// # Ok(())
+/// # }
+/// ```
+pub fn enable() -> Result<bool, SandboxError> {
+    Ok(enable_platform_sandbox()?)
+}
+
+#[cfg(all(
+    any(target_os = "linux", target_os = "android"),
+    target_endian = "little",
+    any(target_arch = "aarch64", target_arch = "x86_64")
+))]
+fn enable_platform_sandbox() -> seccompiler::Result<bool> {
+    use seccompiler::{BpfProgram, SeccompAction, SeccompFilter};
+    use std::env::consts::ARCH;
+
+    // Some syscall numbers aren't yet defined in the libc crate for aarch64. Manually override
+    // them here where necessary until upstream contains all the syscalls we need.
+    //
+    // The values are sourced from
+    // https://android.googlesource.com/platform/bionic/+/0339184/libc/kernel/uapi/asm-generic/unistd.h
+    #[cfg(target_arch = "x86_64")]
+    const SYS_LSEEK: libc::c_long = libc::SYS_lseek;
+    #[cfg(target_arch = "aarch64")]
+    const SYS_LSEEK: libc::c_long = 62;
+    #[cfg(target_arch = "x86_64")]
+    const SYS_MMAP: libc::c_long = libc::SYS_mmap;
+    #[cfg(target_arch = "aarch64")]
+    const SYS_MMAP: libc::c_long = 222;
+
+    let filter: BpfProgram = SeccompFilter::new(
+        vec![
+            (libc::SYS_close, vec![]),
+            (libc::SYS_epoll_pwait, vec![]),
+            (libc::SYS_fcntl, vec![]),
+            (libc::SYS_getsockopt, vec![]),
+            (libc::SYS_getuid, vec![]),
+            (libc::SYS_ioctl, vec![]),
+            (SYS_LSEEK, vec![]),
+            (SYS_MMAP, vec![]),
+            (libc::SYS_munmap, vec![]),
+            (libc::SYS_prctl, vec![]),
+            (libc::SYS_read, vec![]),
+            (libc::SYS_write, vec![]),
+            (libc::SYS_writev, vec![]),
+        ]
+        .into_iter()
+        .collect(),
+        SeccompAction::KillProcess,
+        SeccompAction::Allow,
+        // This should never panic due to conditional compilation
+        ARCH.try_into().unwrap(),
+    )?
+    .try_into()?;
+
+    seccompiler::apply_filter_all_threads(&filter)?;
+
+    Ok(true)
+}
+
+#[cfg(not(all(
+    any(target_os = "linux", target_os = "android"),
+    target_endian = "little",
+    any(target_arch = "aarch64", target_arch = "x86_64")
+)))]
+fn enable_platform_sandbox() -> seccompiler::Result<bool> {
+    Ok(false)
+}


### PR DESCRIPTION
We had to remove support for i686-linux-android since seccompiler doesn't support it. This in turn means we can no longer use ATD system images in our Gradle managed devices. Because we are no longer restricted to SDK 30 by the ATD system image, it seemed to make sense to bump the SDK we test on to the latest, SDK 34.

The sandbox is initialized as soon as the patcher service starts. When sandbox initialization fails, the service aborts itself so that we're never running without the sandbox.

We don't currently have CI tests to verify the seccomp sandbox, but it can be tested locally with `./gradlew allDevicesCheck`.

syscall parameters are currently not filtered. Future commits can likely filter these to further tighten the sandbox.